### PR TITLE
fixed memory leak; new API to allow for non-privileged use of nflog

### DIFF
--- a/examples/TestNflog.py
+++ b/examples/TestNflog.py
@@ -1,0 +1,67 @@
+import os
+import pwd
+import grp
+import nflog
+import time
+import socket
+
+
+# GLOBALS
+count = 0
+l = None
+
+
+def dropPrivileges( uid_name, gid_name):
+    # Get the uid/gid from the name
+    running_uid = pwd.getpwnam(uid_name).pw_uid
+    running_gid = grp.getgrnam(gid_name).gr_gid
+
+    # Remove group privileges
+    os.setgroups([])
+
+    # Try setting the new uid/gid
+    os.setgid(running_gid)
+    os.setuid(running_uid)
+
+    # Ensure a very conservative umask
+    old_umask = os.umask(077)
+    print "now running as non-root: u=%s, g=%s" % (uid_name, gid_name)
+
+
+def callback(pkt):
+    try:
+        global count
+        count += 1
+        payload = pkt.get_data()
+        #time.sleep(0.2) # TODO: enable this to enforce SIGINT in callback
+        print "callback #%06d - %d bytes" % (count, len(payload))
+    except KeyboardInterrupt:
+        global l
+        print "SIGINT in callback(), calling stop_loop()"
+        l.stop_loop()
+
+
+def main():
+    global l
+    NFLOG_GROUP = 1 # TODO: adapt this; default = 0
+    l = nflog.log()
+    l.set_callback(callback)
+    l.fast_open(NFLOG_GROUP, socket.AF_INET)
+    l.prepare()
+    # TODO: change this to users with reduced privileges on your system
+    dropPrivileges('nobody', 'nogroup')
+    print "calling loop()"
+    try:
+        l.loop()
+    except KeyboardInterrupt:
+        print "SIGINT caught in main thread"
+        l.stop_loop()
+        pass # normal; sometimes happens in callback handler, sometimes here
+    finally:
+        print "returned from loop(), will now tear down"
+        #l.unbind(socket.AF_INET) # l.unbind() is privileged (requires root)
+        l.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/example.pl
+++ b/examples/example.pl
@@ -62,6 +62,8 @@ print "open\n";
 $l->fast_open(1, AF_INET);
 
 print "trying to run\n";
-$l->try_run();
+$l->prepare();
 
+print "trying to run\n";
+$l->loop();
 

--- a/libnetfilter_log.i
+++ b/libnetfilter_log.i
@@ -42,7 +42,9 @@
         int create_queue(int);
         int fast_open(int, int);
         int set_bufsiz(int);
-        int try_run();
+        int prepare();
+        int loop();
+        int stop_loop();
 };
 
 %extend log_payload {

--- a/nflog.h
+++ b/nflog.h
@@ -10,6 +10,7 @@ struct log {
 
 	struct nflog_handle *_h;
 	struct nflog_g_handle *_gh;
+	int fd;
 	void *_cb;
 };
 

--- a/nflog_common.h
+++ b/nflog_common.h
@@ -22,7 +22,11 @@ int log_create_queue(struct log *self, int queue_num);
 
 int log_fast_open(struct log *self, int queue_num, int af_family);
 
-int log_try_run(struct log *self);
+int log_prepare(struct log *self);
+
+int log_loop(struct log *self);
+
+int log_stop_loop(struct log *self);
 
 int log_payload_get_nfmark(struct log_payload *self);
 

--- a/python/nflog_python.i
+++ b/python/nflog_python.i
@@ -50,6 +50,10 @@ int  swig_nflog_callback(struct nflog_g_handle *gh, struct nfgenmsg *nfmsg,
                 SWIG_PYTHON_THREAD_BEGIN_ALLOW;
                 func = (PyObject *) data;
                 p = malloc(sizeof(struct log_payload));
+                if (!p) {
+                        fprintf(stderr, "callback malloc failure !\n");
+                        PyErr_Print();
+                }
                 p->data = payload_data;
                 p->len = payload_len;
                 p->id = id;
@@ -58,6 +62,7 @@ int  swig_nflog_callback(struct nflog_g_handle *gh, struct nfgenmsg *nfmsg,
                 payload_obj = SWIG_NewPointerObj((void*) p, SWIGTYPE_p_log_payload, 0 /* | SWIG_POINTER_OWN */);
                 arglist = Py_BuildValue("(N)",payload_obj);
                 result = PyEval_CallObject(func,arglist);
+                free(p);
                 Py_DECREF(arglist);
                 if (result) {
                         Py_DECREF(result);


### PR DESCRIPTION
342400c523a7ff65221729df50d9c6229690de45 fixes the memory leak

All the other commits are regarding the change of the API. I propose to use replace
   try_loop()
with
   prepare() // privileged call; prepares the nflog file descriptor etc.
   loop() // non-privileged call; endless loop
   stop_loop() // non-privileged call; terminates the endless loop

Furthermore, I use setsockopt() to avoid the ENOBUFS errors occuring within the loop, such that the loop only need to called once (and not in a loop itself).
