### PR TITLE
Release python GIL while blocking at recv()

### DIFF
--- a/nflog_common.c
+++ b/nflog_common.c
@@ -142,18 +142,6 @@ int log_stop_loop(struct log *self)
 	return 0;
 }
 
-int log_loop(struct log *self)
-{
-	int rv;
-	char buf[65535];
-
-	while ((rv = recv(self->fd, buf, sizeof(buf), 0)) && rv >= 0 && self->_h) {
-		nflog_handle_packet(self->_h, buf, rv);
-	}
-
-	return 0;
-}
-
 int log_prepare(struct log *self)
 {
 	int rv;

--- a/nflog_common.h
+++ b/nflog_common.h
@@ -32,8 +32,6 @@ int log_fast_open(struct log *self, int queue_num, int af_family);
 
 int log_prepare(struct log *self);
 
-int log_loop(struct log *self);
-
 int log_stop_loop(struct log *self);
 
 int log_payload_get_nfmark(struct log_payload *self);

--- a/perl/nflog_perl.i
+++ b/perl/nflog_perl.i
@@ -92,6 +92,17 @@ int set_callback(void *perl_cb)
         return 0;
 }
 
+int loop()
+{
+	int rv;
+	char buf[65535];
+
+	while ((rv = recv(self->fd, buf, sizeof(buf), 0)) && rv >= 0 && self->_h) {
+		nflog_handle_packet(self->_h, buf, rv);
+	}
+
+	return 0;
+}
 };
 
 %typemap (out) const char* get_data {

--- a/python/nflog_python.i
+++ b/python/nflog_python.i
@@ -92,6 +92,22 @@ int set_callback(PyObject *pyfunc)
         return 0;
 }
 
+int loop()
+{
+	int rv;
+	char buf[65535];
+
+	Py_BEGIN_ALLOW_THREADS
+	while ((rv = recv(self->fd, buf, sizeof(buf), 0)) && rv >= 0 && self->_h) {
+		Py_BLOCK_THREADS
+		nflog_handle_packet(self->_h, buf, rv);
+		Py_UNBLOCK_THREADS
+	}
+	Py_END_ALLOW_THREADS
+
+	return 0;
+}
+
 };
 
 %typemap (out) const char* get_data {


### PR DESCRIPTION
The call to recv() constitutes blocking I/O.
Releasing the GIL while waiting for the blocking I/O to finish allows python to schedule other threads in between.
